### PR TITLE
Add support for DateInterval type

### DIFF
--- a/src/Raven.Client.NodaTime/Extensions.cs
+++ b/src/Raven.Client.NodaTime/Extensions.cs
@@ -55,6 +55,7 @@ namespace Raven.Client.NodaTime
                 serializer.Converters.Add(new DurationConverter());
                 serializer.Converters.Add(new OffsetDateTimeConverter());
                 serializer.Converters.Add(new ZonedDateTimeConverter());
+                serializer.Converters.Add(new DateIntervalConverter());
             };
 
             // Register query value converters

--- a/src/Raven.Client.NodaTime/JsonConverters/DateIntervalConverter.cs
+++ b/src/Raven.Client.NodaTime/JsonConverters/DateIntervalConverter.cs
@@ -1,0 +1,63 @@
+﻿using System.IO;
+using Newtonsoft.Json;
+using NodaTime;
+using Raven.Imports.NodaTime.Serialization.JsonNet;
+
+namespace Raven.Client.NodaTime.JsonConverters
+{
+    /// <summary>
+    /// Reads Start and End properties as LocalDates.
+    /// </summary>
+    internal class DateIntervalConverter : NodaConverterBase<DateInterval>
+    {
+        protected override DateInterval ReadJsonImpl(JsonReader reader, JsonSerializer serializer)
+        {
+            var startLocalDate = default(LocalDate);
+            var endLocalDate = default(LocalDate);
+            var gotStartLocalDate = false;
+            var gotEndLocalDate = false;
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    break;
+                }
+
+                var propertyName = (string)reader.Value;
+                if (!reader.Read())
+                {
+                    continue;
+                }
+
+                if (propertyName == "Start")
+                {
+                    startLocalDate = serializer.Deserialize<LocalDate>(reader);
+                    gotStartLocalDate = true;
+                }
+
+                if (propertyName == "End")
+                {
+                    endLocalDate = serializer.Deserialize<LocalDate>(reader);
+                    gotEndLocalDate = true;
+                }
+            }
+
+            if (!(gotStartLocalDate && gotEndLocalDate))
+            {
+                throw new InvalidDataException("A DateInterval must contain Start and End properties.");
+            }
+
+            return new DateInterval(startLocalDate, endLocalDate);
+        }
+
+        protected override void WriteJsonImpl(JsonWriter writer, DateInterval value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("Start");
+            serializer.Serialize(writer, value.Start);
+            writer.WritePropertyName("End");
+            serializer.Serialize(writer, value.End);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/test/Raven.Client.NodaTime.Tests/NodaDateIntervalTests.cs
+++ b/test/Raven.Client.NodaTime.Tests/NodaDateIntervalTests.cs
@@ -1,0 +1,58 @@
+﻿using NodaTime;
+using NodaTime.Text;
+using Raven.Client.Documents.Commands;
+using Sparrow.Json;
+using Xunit;
+
+namespace Raven.Client.NodaTime.Tests
+{
+    public class NodaDateIntervalTests : MyRavenTestDriver
+    {
+        [Fact]
+        public void Can_Use_NodaTime_DateInterval_In_Document()
+        {
+            var today = NodaUtil.LocalDate.Today;
+            var start = today.PlusDays(-1);
+            var end = today.PlusDays(1);
+            var dateInterval = new DateInterval(start, end);
+
+            using (var documentStore = NewDocumentStore())
+            {
+                using (var session = documentStore.OpenSession())
+                {
+                    session.Store(new Foo { Id = "foos/1", DateInterval = dateInterval });
+                    session.SaveChanges();
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    var foo = session.Load<Foo>("foos/1");
+
+                    Assert.Equal(dateInterval, foo.DateInterval);
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    var command = new GetDocumentsCommand("foos/1", null, false);
+                    session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                    var json = (BlittableJsonReaderObject)command.Result.Results[0];
+                    System.Diagnostics.Debug.WriteLine(json.ToString());
+                    var expectedStart = dateInterval.Start.ToString(LocalDatePattern.Iso.PatternText, null);
+                    var expectedEnd = dateInterval.End.ToString(LocalDatePattern.Iso.PatternText, null);
+                    json.TryGetMember("DateInterval", out var obj);
+                    var bInterval = obj as BlittableJsonReaderObject;
+                    bInterval.TryGet("Start", out string valueStart);
+                    bInterval.TryGet("End", out string valueEnd);
+                    Assert.Equal(expectedStart, valueStart);
+                    Assert.Equal(expectedEnd, valueEnd);
+                }
+            }
+        }
+
+        public class Foo
+        {
+            public string Id { get; set; }
+            public DateInterval DateInterval { get; set; }
+        }
+    }
+}

--- a/test/Raven.Client.NodaTime.Tests/NodaDateIntervalTests.cs
+++ b/test/Raven.Client.NodaTime.Tests/NodaDateIntervalTests.cs
@@ -2,6 +2,7 @@
 using NodaTime;
 using NodaTime.Text;
 using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
 using Sparrow.Json;
 using Xunit;
 
@@ -92,10 +93,67 @@ namespace Raven.Client.NodaTime.Tests
             }
         }
 
+        [Fact]
+        public void Can_Use_NodaTime_DateInterval_In_Static_Index()
+        {
+            var today = NodaUtil.LocalDate.Today;
+            var start = today.PlusDays(-1);
+            var end = today.PlusDays(1);
+            var dateInterval1 = new DateInterval(start, end);
+            var dateInterval2 = new DateInterval(end, end.PlusDays(1));
+
+            using (var documentStore = NewDocumentStore())
+            {
+                documentStore.ExecuteIndex(new TestIndex());
+
+                using (var session = documentStore.OpenSession())
+                {
+                    session.Store(new Foo { Id = "foos/1", DateInterval = dateInterval1 });
+                    session.Store(new Foo { Id = "foos/2", DateInterval = dateInterval2 });
+                    session.SaveChanges();
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    var q1 = session.Query<Foo, TestIndex>()
+                                    .Customize(x => x.WaitForNonStaleResults())
+                                    .Where(x => x.DateInterval.Start == dateInterval1.Start && x.DateInterval.End == dateInterval1.End);
+                    var results1 = q1.ToList();
+                    Assert.Single(results1);
+
+                    var q2 = session.Query<Foo, TestIndex>()
+                                    .Customize(x => x.WaitForNonStaleResults())
+                                    .Where(x => x.DateInterval.Start <= today && x.DateInterval.End > today);
+                    var results2 = q2.ToList();
+                    Assert.Single(results2);
+
+                    var q3 = session.Query<Foo, TestIndex>()
+                                    .Customize(x => x.WaitForNonStaleResults())
+                                    .OrderByDescending(x => x.DateInterval.Start);
+                    var results3 = q3.ToList();
+                    Assert.Equal(2, results3.Count);
+                    Assert.True(results3[0].DateInterval.Start > results3[1].DateInterval.Start);
+                }
+            }
+        }
+
         public class Foo
         {
             public string Id { get; set; }
             public DateInterval DateInterval { get; set; }
+        }
+
+        public class TestIndex : AbstractIndexCreationTask<Foo>
+        {
+            public TestIndex()
+            {
+                Map = foos => from foo in foos
+                              select new
+                              {
+                                  DateInterval_Start = foo.DateInterval.Start,
+                                  DateInterval_End = foo.DateInterval.End
+                              };
+            }
         }
     }
 }

--- a/test/Raven.Client.NodaTime.Tests/NodaDateIntervalTests.cs
+++ b/test/Raven.Client.NodaTime.Tests/NodaDateIntervalTests.cs
@@ -1,4 +1,5 @@
-﻿using NodaTime;
+﻿using System.Linq;
+using NodaTime;
 using NodaTime.Text;
 using Raven.Client.Documents.Commands;
 using Sparrow.Json;
@@ -45,6 +46,48 @@ namespace Raven.Client.NodaTime.Tests
                     bInterval.TryGet("End", out string valueEnd);
                     Assert.Equal(expectedStart, valueStart);
                     Assert.Equal(expectedEnd, valueEnd);
+                }
+            }
+        }
+
+        [Fact]
+        public void Can_Use_NodaTime_DateInterval_In_Dynamic_Index()
+        {
+            var today = NodaUtil.LocalDate.Today;
+            var start = today.PlusDays(-1);
+            var end = today.PlusDays(1);
+            var dateInterval1 = new DateInterval(start, end);
+            var dateInterval2 = new DateInterval(end, end.PlusDays(1));
+
+            using (var documentStore = NewDocumentStore())
+            {
+                using (var session = documentStore.OpenSession())
+                {
+                    session.Store(new Foo { Id = "foos/1", DateInterval = dateInterval1 });
+                    session.Store(new Foo { Id = "foos/2", DateInterval = dateInterval2 });
+                    session.SaveChanges();
+                }
+
+                using (var session = documentStore.OpenSession())
+                {
+                    var q1 = session.Query<Foo>()
+                                    .Customize(x => x.WaitForNonStaleResults())
+                                    .Where(x => x.DateInterval.Start == dateInterval1.Start && x.DateInterval.End == dateInterval1.End);
+                    var results1 = q1.ToList();
+                    Assert.Single(results1);
+
+                    var q2 = session.Query<Foo>()
+                                    .Customize(x => x.WaitForNonStaleResults())
+                                    .Where(x => x.DateInterval.Start <= today && x.DateInterval.End > today);
+                    var results2 = q2.ToList();
+                    Assert.Single(results2);
+
+                    var q3 = session.Query<Foo>()
+                                    .Customize(x => x.WaitForNonStaleResults())
+                                    .OrderByDescending(x => x.DateInterval.Start);
+                    var results3 = q3.ToList();
+                    Assert.Equal(2, results3.Count);
+                    Assert.True(results3[0].DateInterval.Start > results3[1].DateInterval.Start);
                 }
             }
         }


### PR DESCRIPTION
As discussed (#26 ), this adds support for the `DateInterval`. I've basically used the `Interval` implementation, so this adds a bit of duplication. However, looking around in this project, I see this is how you did most of the stuff (which I can related to, this is a very simple project, not a lot of churn, so this risk of a bit of duplication is very low).

One thing, I saw that the [3rd assertion in `Can_Use_NodaTime_Interval_In_Static_Index()`](https://github.com/ryanheath/RavenDB-NodaTime/blob/a5a1123829144e4526f01417b55393800bfd5725/test/Raven.Client.NodaTime.Tests/NodaIntervalTests.cs#L129) didn't use the index, which is probably a copy-paste bug. I've boyscouted that in the new `NodaDateIntervalTests`, however, I've left the `NodaIntervalTests.cs` untouched.