### PR TITLE
Switch to using PackageLicenseExpression

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,17 +9,20 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore -p:ContinuousIntegrationBuild=true
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --configuration Release --no-restore --no-build --verbosity normal
+    - name: Pack
+      run: dotnet pack --configuration Release --no-restore --no-build
+    - name: Publish artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet packages
+        path: '**/*.nupkg'

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ Backup*/
 UpgradeLog*.XML
 
 /.vs
+/.idea

--- a/src/Raven.Bundles.NodaTime/Raven.Bundles.NodaTime.csproj
+++ b/src/Raven.Bundles.NodaTime/Raven.Bundles.NodaTime.csproj
@@ -6,18 +6,18 @@
     <Authors>Matt Johnson;Ryan Heath</Authors>
     <PackageTags>ravendb;raven db;noda time;nodatime</PackageTags>
     <PackageProjectUrl>https://github.com/ryanheath/RavenDB-NodaTime</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>http://static.ravendb.net/logo-for-nuget.png</PackageIconUrl>
     <PackageIcon>logo-for-nuget.png</PackageIcon>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>5.3.102</Version>
+    <Version>5.4.1</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
     <None Include="..\..\logo-for-nuget.png" Pack="true" PackagePath="\" />
-    <PackageReference Include="NodaTime" Version="2.4.5" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.102" />
+    <PackageReference Include="NodaTime" Version="3.1.11" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
   </ItemGroup>
 </Project>

--- a/src/Raven.Client.NodaTime/Raven.Client.NodaTime.csproj
+++ b/src/Raven.Client.NodaTime/Raven.Client.NodaTime.csproj
@@ -6,26 +6,20 @@
     <Authors>Matt Johnson;Ryan Heath</Authors>
     <PackageTags>ravendb;raven db;noda time;nodatime</PackageTags>
     <PackageProjectUrl>https://github.com/mj1856/RavenDB-NodaTime</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>http://static.ravendb.net/logo-for-nuget.png</PackageIconUrl>
     <PackageIcon>logo-for-nuget.png</PackageIcon>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>5.3.102</Version>
+    <Version>5.4.1</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
+    <PackageReference Include="NodaTime" Version="3.1.11" />
+    <PackageReference Include="RavenDB.Client" Version="5.4.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
     <None Include="..\..\logo-for-nuget.png" Pack="true" PackagePath="\" />
-    <PackageReference Include="NodaTime" Version="2.4.5" />
-    <PackageReference Include="RavenDB.Client" Version="5.3.102" />
   </ItemGroup>
 </Project>

--- a/test/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
+++ b/test/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
@@ -8,14 +8,12 @@
     <ProjectReference Include="..\..\src\Raven.Client.NodaTime\Raven.Client.NodaTime.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NodaTime" Version="2.4.5" />
-	<PackageReference Include="RavenDB.Client" Version="5.3.102" />
-	<PackageReference Include="RavenDB.TestDriver" Version="5.3.101" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+	<PackageReference Include="RavenDB.TestDriver" Version="5.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* License expression is the preferred way (shows in NuGet.org and used in license validations).
* Also updated GH Actions workflow definition to use current actions, running on fast fast Ubuntu runner and publishing the NuGet packages with proper compiler flags (deterministic CI build in release mode)
* Updated to target RavenDB 5.4.1 and latest NodaTime
* Updated testing libraries
