### PR TITLE
Bumped Raven client to 6.2.3

### DIFF
--- a/src/Raven.Bundles.NodaTime/Raven.Bundles.NodaTime.csproj
+++ b/src/Raven.Bundles.NodaTime/Raven.Bundles.NodaTime.csproj
@@ -11,13 +11,13 @@
     <PackageIcon>logo-for-nuget.png</PackageIcon>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>6.0.106</Version>
+    <Version>6.2.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
     <None Include="..\..\logo-for-nuget.png" Pack="true" PackagePath="\" />
-    <PackageReference Include="NodaTime" Version="3.1.12" />
-    <PackageReference Include="RavenDB.Client" Version="6.0.106" />
+    <PackageReference Include="NodaTime" Version="3.2.1" />
+    <PackageReference Include="RavenDB.Client" Version="6.2.3" />
   </ItemGroup>
 </Project>

--- a/src/Raven.Client.NodaTime/Raven.Client.NodaTime.csproj
+++ b/src/Raven.Client.NodaTime/Raven.Client.NodaTime.csproj
@@ -11,12 +11,12 @@
     <PackageIcon>logo-for-nuget.png</PackageIcon>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>6.0.106</Version>
+    <Version>6.2.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.1.12" />
-    <PackageReference Include="RavenDB.Client" Version="6.0.106" />
+    <PackageReference Include="NodaTime" Version="3.2.1" />
+    <PackageReference Include="RavenDB.Client" Version="6.2.3" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />

--- a/test/Raven.Client.NodaTime.Tests/MyRavenTestDriver.cs
+++ b/test/Raven.Client.NodaTime.Tests/MyRavenTestDriver.cs
@@ -5,10 +5,26 @@ namespace Raven.Client.NodaTime.Tests
 {
     public class MyRavenTestDriver : RavenTestDriver
     {
+        private static bool _hasBeenConfigured;
+        
+        protected MyRavenTestDriver()
+        {
+            if (_hasBeenConfigured) 
+                return;
+            
+            ConfigureServer(new TestServerOptions
+            {
+                Licensing =
+                {
+                    ThrowOnInvalidOrMissingLicense = false
+                }
+            });
+            _hasBeenConfigured = true;
+        }
+
         protected override void PreInitialize(IDocumentStore documentStore)
         {
             documentStore.ConfigureForNodaTime();
-
             base.PreInitialize(documentStore);
         }
 

--- a/test/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
+++ b/test/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
 	<Nullable>disable</Nullable>
 	<IsPackable>false</IsPackable>
-	<LangVersion>12</LangVersion>
+	<LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Raven.Client.NodaTime\Raven.Client.NodaTime.csproj" />

--- a/test/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
+++ b/test/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<Nullable>disable</Nullable>
 	<IsPackable>false</IsPackable>
+	<LangVersion>12</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Raven.Client.NodaTime\Raven.Client.NodaTime.csproj" />

--- a/test/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
+++ b/test/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
@@ -8,12 +8,12 @@
     <ProjectReference Include="..\..\src\Raven.Client.NodaTime\Raven.Client.NodaTime.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-	<PackageReference Include="RavenDB.TestDriver" Version="6.0.106" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+	<PackageReference Include="RavenDB.TestDriver" Version="6.2.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumped Raven client to 6.2.3. Bumped NodaTime to 3.2.1. Updated test driver to handle new licensing default.